### PR TITLE
remove protocol identifier to be ready for https

### DIFF
--- a/leaflet-bing-layer.js
+++ b/leaflet-bing-layer.js
@@ -57,8 +57,8 @@ L.TileLayer.Bing = L.TileLayer.extend({
   },
 
   statics: {
-    METADATA_URL: 'http://dev.virtualearth.net/REST/v1/Imagery/Metadata/{imagerySet}?key={bingMapsKey}&include=ImageryProviders',
-    POINT_METADATA_URL: 'http://dev.virtualearth.net/REST/v1/Imagery/Metadata/{imagerySet}/{lat},{lng}?zl={z}&key={bingMapsKey}'
+    METADATA_URL: '//dev.virtualearth.net/REST/v1/Imagery/Metadata/{imagerySet}?key={bingMapsKey}&include=ImageryProviders',
+    POINT_METADATA_URL: '//dev.virtualearth.net/REST/v1/Imagery/Metadata/{imagerySet}/{lat},{lng}?zl={z}&key={bingMapsKey}'
   },
 
   initialize: function (options) {
@@ -368,7 +368,7 @@ module.exports = function(bbox1, bbox2){
       throw new Error('polyfill failed because global object is unavailable in this environment');
     }
   }
-  
+
   local.fetchJsonp = fetchJsonp;
   */
 


### PR DESCRIPTION
When I tried to use leaflet-bing-layer in production with https it turned out, that  'Blocked loading mixed content' stopped the map loading correctly. Removing the protocol identifier completely solved this problem for me. I don't know if this solution is good for all browsers you want to support.
