### PR TITLE
request metadata with HTTPS urls

### DIFF
--- a/leaflet-bing-layer.js
+++ b/leaflet-bing-layer.js
@@ -57,8 +57,8 @@ L.TileLayer.Bing = L.TileLayer.extend({
   },
 
   statics: {
-    METADATA_URL: 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/{imagerySet}?key={bingMapsKey}&include=ImageryProviders',
-    POINT_METADATA_URL: 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/{imagerySet}/{lat},{lng}?zl={z}&key={bingMapsKey}'
+    METADATA_URL: 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/{imagerySet}?key={bingMapsKey}&include=ImageryProviders&uriScheme=https',
+    POINT_METADATA_URL: 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/{imagerySet}/{lat},{lng}?zl={z}&key={bingMapsKey}&uriScheme=https'
   },
 
   initialize: function (options) {


### PR DESCRIPTION
I ran into an problem where this plugin was pulling Bing metadata via HTTPS, but the URLs within the metadata were still HTTP URLs, which throws warnings in at least Edge and Firefox. Per [this documentation](https://msdn.microsoft.com/en-us/library/ff701716.aspx) I've added a `uriScheme` parameter, which fixes the issue.