### PR TITLE
Set min/max Native Zoom for Tile Layers

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,8 @@ L.TileLayer.Bing = L.TileLayer.extend({
     bingMapsKey: null, // Required
     imagerySet: 'Aerial',
     culture: 'en-US',
-    minZoom: 1
+	minNativeZoom: 1,
+	maxNativeZoom: 19
   },
 
   statics: {
@@ -83,8 +84,6 @@ L.TileLayer.Bing = L.TileLayer.extend({
     if (VALID_IMAGERY_SETS.indexOf(options.imagerySet) < 0) {
       throw new Error("'" + options.imagerySet + "' is an invalid imagerySet, see https://github.com/digidem/leaflet-bing-layer#parameters")
     }
-    // Bing maps do not have zoom=0 tiles.
-    options.minZoom = Math.max(1, options.minZoom)
 
     var metaDataUrl = L.Util.template(L.TileLayer.Bing.METADATA_URL, {
       bingMapsKey: this.options.bingMapsKey,

--- a/index.js
+++ b/index.js
@@ -60,8 +60,8 @@ L.TileLayer.Bing = L.TileLayer.extend({
     bingMapsKey: null, // Required
     imagerySet: 'Aerial',
     culture: 'en-US',
-	minNativeZoom: 1,
-	maxNativeZoom: 19
+    minNativeZoom: 1,
+    maxNativeZoom: 19
   },
 
   statics: {

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ L.TileLayer.Bing = L.TileLayer.extend({
     bingMapsKey: null, // Required
     imagerySet: 'Aerial',
     culture: 'en-US',
+    minZoom: 1,
     minNativeZoom: 1,
     maxNativeZoom: 19
   },


### PR DESCRIPTION
This PR defaults the min/max native zoom levels to the levels provided by Bing's API. It also removes code that overwrites the minZoom option when it is less than 1 since that shouldn't be necessary now that minNativeZoom is specified. 