### PR TITLE
Fixed imageryProviders and imageUrlSubdomains

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ L.TileLayer.Bing = L.TileLayer.extend({
     }
     var resource = metaData.resourceSets[0].resources[0]
     this._url = resource.imageUrl
-    this._imageryProviders = resource.imageryProviders
+    this._imageryProviders = resource.imageryProviders || []
     this.options.subdomains = resource.imageUrlSubdomains
     this._updateAttribution()
     return Promise.resolve()


### PR DESCRIPTION
It turns out only 'Aerial', 'AerialWithLabels' and 'Road' imagery sets return metadata with resource.imageryProviders defined. Thus later uses of this._imageryProviders was failing. This fix ensures that there is at least an empty array.