### PR TITLE
Update attribution when adding layer after map is added to the DOM

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,6 +152,11 @@ L.TileLayer.Bing = L.TileLayer.extend({
   onAdd: function (map) {
     map.on('moveend', this._updateAttribution, this)
     L.TileLayer.prototype.onAdd.call(this, map)
+
+    if (this._attributions.length === 0) {
+      this._updateAttribution()
+    }
+
     this._attributions.forEach(function (attribution) {
       map.attributionControl.addAttribution(attribution)
     })


### PR DESCRIPTION
This fixes the attributions not being fetched and not showing initially when the map is added to the DOM and the layer is added to the map at a later point (e.g. on a button click).

Demo of the issue: https://jsfiddle.net/agorf/tphbuLvu/

To reproduce, once the demo page loads, click on the button to add the layer. You will notice the attribution is still missing (it's still left as "Leaflet"). It is correctly updated only once the map is moved.