### PR TITLE
Use tile zoom rather than map zoom to get attributions

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,11 @@ L.TileLayer.Bing = L.TileLayer.extend({
   _updateAttribution: function () {
     var map = this._map
     if (!map || !map.attributionControl) return
-    var zoom = map.getZoom()
+
+    // map zoom can be out of bounds of native zoom levels, use the
+    // zoom level of the request tile instead
+    var zoom = this._tileZoom
+
     var bbox = toBingBBox(map.getBounds().toBBoxString())
     this._fetch.then(function () {
       var newAttributions = this._getAttributions(bbox, zoom)


### PR DESCRIPTION
If map is zoomed further that `maxNativeZoom` allows, the zoom level used to match attributions should be that used to fetch the tiles from the server, i.e. the clamped zoom level.