### PR TITLE
Ensure attributions are correctly added/remove when layers are switched

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,6 +232,9 @@ L.TileLayer.Bing = L.TileLayer.extend({
     var zoom = map.getZoom()
     var bbox = toBingBBox(map.getBounds().toBBoxString())
     this._fetch.then(function () {
+      // Layer has been removed during fetch
+      if (!this._map) return
+
       var newAttributions = this._getAttributions(bbox, zoom)
       var prevAttributions = this._attributions
       // Add any new provider attributions in the current area to the attribution control

--- a/index.js
+++ b/index.js
@@ -177,6 +177,7 @@ L.TileLayer.Bing = L.TileLayer.extend({
     this._attributions.forEach(function (attribution) {
       map.attributionControl.removeAttribution(attribution)
     })
+    this._attributions = []
     L.TileLayer.prototype.onRemove.call(this, map)
   },
 


### PR DESCRIPTION
Currently, switching layers away from leaflet-bing-layer can lead to attributions being left behind, which switching to it can lead to attributions being prematurely removed.  This PR fixes these issues